### PR TITLE
Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,32 @@ To ensure XDG compliance environment variables should be set up to conform to th
 [[ -n "$LC_CTYPE" ]] || export LC_CTYPE="en_US.UTF-8"
 ```
 
-### Installing software
-The list below includes packages which are referenced or used in the various configuration files in this repository and create a working base install of the environment. All personal `$USER` applications have been omitted as they vary per system installation. Instead, these have been listed under the section 'Optional software packages' below. 
+### Enabling multilib repositories
+Several applications require 32-bit libraries. These can be retrieved after enabling the `multilib` repository in `/etc/pacman.conf`. 
+
+### Selecting the fastest mirror
+
 ```
-sudo apt install \
-   cmake compton curl dkms exuberant-ctags feh flake8 gvfs gvfs-backends i3 i3blocks i3lock    \
-   i3status imagemagick libssl-dev lxappearance numlockx pavucontrol policykit-1 pulseaudio    \
-   python-dev python-pip python3-dev python3-pip rofi rxvt-unicode-256color scrot thunar       \
-   thunar-volman tmux udisks2 x11-apps x11-session-utils x11-utils x11-xserver-utils xautolock \
-   xbacklight xfonts-base xinit xinput xorg xserver-xorg xserver-xorg-core                     \
-   xserver-xorg-input-synaptics xss-lock zsh
+sudo pacman -S --noconfirm --needed reflector
+sudo reflector -l 100 -f 50 --sort rate --threads 5 --verbose --save /tmp/mirrorlist.new
+rankmirrors -n 0 /tmp/mirrorlist.new > /tmp/mirrorlistsudo 
+cp /tmp/mirrorlist /etc/pacman.d && sudo pacman -Syu
+```
+
+### Install XOrg and video driver(s)
+
+```
+sudo pacman -S --noconfirm --needed \
+   xorg-server xorg-apps xorg-xinit xorg-twm xterm xf86-video-intel
+```
+
+### Install essential software
+The list below includes packages which are referenced or used in the various configuration files in this repository and create a working base install of the environment. All personal `$USER` applications have been omitted as they vary per system installation. Instead, these have been listed under the section 'Optional software packages' below. 
+
+```
+sudo pacman -S --noconfirm --needed \   
+   acpi acpid alsa-firmware alsa-plugins alsa-utils android-tools ansible arandr baobab blueberry bluez-firmware bluez-utils bmon bridge-utils cheese cifs-utils cmake compton cups cups-pdf curl dhclient dialog dkms docker dunst etckeeper feh ffmpeg file-roller firefox flake8 flashplugin ghostscript gksu gnome-keyring gparted gsfonts gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer gvfs gvfs-mtp gvfs-nfs gvfs-smb hplip htop i3status imagemagick iperf iperf3 jre9-openjdk libcups libvirt linux-headers lm_sensors lsb-release lxappearance minicom mousetweaks mtr neovim net-tools networkmanager network-manager-applet nftables nmap numix-gtk-theme numlockx openconnect openssh openssl openvpn p7zip pavucontrol polkit powertop pulseaudio pulseaudio-alsa putty python python-pip python2 python2-pip ranger redshift remmina rofi ruby sane screen screenfetch scrot sshpass simple-scan sslscan xf86-input-libinput syncthing system-config-printer tcpdump thunar thunar-volman thunderbird tlp tlp-rdw tmux traceroute transmission-qt tree ttf-roboto udev udisks2 unrar unzip vagrant virt-manager virtualbox vlc wget whois wireshark-cli wireshark-common wireshark-qt x11-ssh-askpass xautolock xclip xdg-user-dirs xfce4-notes-plugin xss-lock zip zsh    
+
 ```
 In order to trigger `.zlogin` (and thus the following `.xinitrc`), `zsh` should be made the default login shell for the current user:
 ```
@@ -37,14 +53,16 @@ Additionally, `zsh` can be made XDG compliant by including the default XDG direc
 ```
 echo -e "\nif [[ -z "$XDG_CONFIG_HOME" ]]; then\n  export XDG_CONFIG_HOME="$HOME/.config/"\nfi\n\nif [[ -d "$XDG_CONFIG_HOME/zsh" ]]; then\n  export ZDOTDIR="$XDG_CONFIG_HOME/zsh/"\nfi" | sudo tee -a /etc/zsh/zshenv
 ```
-
-Neovim is currently not included in the default Ubuntu repositories but can be installed from `nvim`'s unstable PPA's:
+### Install AUR helper `pacaur` 
 ```
-sudo add-apt-repository -y ppa:neovim-ppa/unstable
-sudo apt-get update -y && sudo apt-get install -y neovim
+curl -Ls https://goo.gl/cF2iJy | bash
+```
+### Installing additional software
+```
+pacaur -S --noconfirm --noedit universal-ctags-git rxvt-unicode-patched arping-th ostinato solaar gnome-ssh-askpass2 rar font-manager hardcode-fixer-git dropbox foxitreader numix-icon-theme-git numix-circle-icon-theme-git neofetch pkgcacheclean slack-desktop spotify keepassxc-git davmail ttf-fantasque-sans-mono powerline-fonts-git ttf-font-awesome-4 gtk-theme-arc-git icaclient eve-ng-integration i3lock-color-git j4-dmenu-desktop i3blocks i3-gaps-next-git teamviewer remmina-plugin-teamviewer displaylink
 ```
 
-### Set up plugin manager(s)
+### Setting up plugin manager(s)
 `vim-plug` allows for leveraging `nvim`'s asynchronous behavior. `zsh` plugins are handled by `zplug` which is self-contained within `$XDG_CONFIG_HOME/zsh/.zshrc`.
 ```
 # vim-plug
@@ -52,30 +70,12 @@ curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
-### Install custom fonts
-The fonts below are referenced in the `rofi`, `i3` and `rxvt-unicode` configuration files.
+### Enable services
 ```
-# Powerline fonts
-git clone https://github.com/powerline/fonts
-mkdir -p $XDG_DATA_HOME/fonts/ && chmod +x fonts/install.sh && sudo fonts/install.sh
-rm -rf ~/fonts/
-
-# FantasqueSansMono
-wget https://github.com/belluzj/fantasque-sans/releases/download/v1.7.1/FantasqueSansMono.tar.gz
-mkdir -p $XDG_DATA_HOME/fonts && tar -xzf FantasqueSansMono.tar.gz --wildcards '*.ttf' && mv ~/*.ttf $XDG_DATA_HOME/fonts/
-rm FantasqueSansMono.tar.gz
-
-# Roboto
-git clone https://github.com/google/fonts/
-mkdir -p $XDG_DATA_HOME/fonts && cp ~/fonts/apache/roboto/*.ttf $XDG_DATA_HOME/fonts
-rm -rf ~/fonts/
-
-# Font-Awesome
-git clone https://github.com/FortAwesome/Font-Awesome/
-mv ~/Font-Awesome/fonts/fontawesome-webfont.ttf $XDG_DATA_HOME/fonts/ && rm -rf ~/Font-Awesome/
-
-# Update font-cache
-fc-cache -f -v
+sudo systemctl enable NetworkManager.service
+sudo systemctl enable org.cups.cupsd.service
+sudo systemctl enable bluetooth.service
+sudo systemctl enable sshd.service
 ```
 
 ### Clone dotfiles into correct directories
@@ -130,10 +130,6 @@ Edit the default message when logging in from the console (`ttyX`).
 ```
 echo -e "Use of this system constitutes consent to monitoring. Monitoring may be\nconducted for the protection against improper or unauthorized use or access.\n\n" | sudo tee /etc/issue
 ```
-Prevent scripts in /etc/update-motd.d/ from executing to remove the default messages:
-```
-sudo chmod -x /etc/update-motd.d/*
-```
 
 #### Fixing audio popping on the Dell E7470
 The Dell E7470 suffers from occasional audio popping when running the 4.X kernel branch. As a workaround the loopback device can be disabled by running the command below and navigating to the specific device. 
@@ -147,57 +143,9 @@ By default Ubuntu performs dynamic naming of network interfaces. To revert to a 
 ```
 sed -i '/GRUB_CMDLINE_LINUX/{s/\"\"/\"net\.ifnames\=0\"/g;s/#//g}' /etc/default/grub
 ```
-
-### Optional software packages
-
-#### Environment themes
-Add the theme repositories:
-
-`numix-icon-theme` & `arc-theme`
-
-```
-wget -nv http://download.opensuse.org/repositories/home:Horst3180/xUbuntu_16.04/Release.key -O Release.key
-sudo apt-key add - < Release.key
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/Horst3180/xUbuntu_16.04/ /' > /etc/apt/sources.list.d/arc-theme.list"
-sudo add-apt-repository -y ppa:numix/ppa
-sudo apt update && sudo apt install arc-theme numix-icon-theme
-```
-Note that themes still have to be applied with `lxappearance`.
-
-#### Workflow software packages
-Enable the partner repository in `/etc/apt/sources.list`:
-```
-sudo sed -i.bak "/^# deb .*partner/ s/^# //" /etc/apt/sources.list && sudo apt update
-```
-The software packages below add on to the base install to create a workable environment:
-```
-sudo snap install keepassxc
-sudo apt install \
-   adobe-flashplugin android-tools-adb android-tools-fastboot arandr arping bmon bridge-utils    \
-   cheese cifs-utils default-jre etckeeper ffmpeg file-roller firefox gnome-keyring gnupg2       \
-   gparted htop iperf iperf3 lm-sensors minicom mousetweaks mtr network-manager nftables         \
-   network-manager-gnome nmap numix-gtk-theme openconnect openvpn ostinato p7zip-full putty      \
-   powertop ranger redshift remmina remmina-plugin-rdp remmina-plugin-vnc screenfetch solaar     \
-   ssh-askpass ssh-askpass-gnome thunderbird tlp tlp-rdw traceroute transmission-gtk tree        \
-   tshark udev unrar unzip virt-manager virtualbox vlc whois wireshark wpasupplicant xfce4-notes
-```
+### Correcting permissions
 In order to run `minicom`, `pcap` without root permissions and allow device mounting in `virtualbox` the following groups should be added to the current user:
 
 ```
-sudo usermod -a -G dialout,wireshark,virtualbox $USER
-```
-
-The software packages below require manual installation:
-
-+ [`davmail`](http://davmail.sourceforge.net/download.html)
-+ [`syncthing`](https://apt.syncthing.net)
-+ [`hplip`](http://hplipopensource.com/hplip-web/downloads.html)
-+ [`spotify`](https://www.spotify.com/nl/download/linux/)
-+ [`teamviewer`](https://www.teamviewer.com/en/download/linux/)
-
-#### DisplayLink driver 
-The easiest way to install the DisplayLink driver for Debian based distributions is by using `/u/AdnanHodzic`'s install script:
-```
-git clone https://github.com/AdnanHodzic/displaylink-debian && cd displaylink-debian
-sudo ./displaylink-debian.sh
+sudo usermod -aG dialout,wireshark,virtualbox $USER
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following steps set up the correct `env` variables, install essential softwa
 
 ### Defining `env` variables
 To ensure XDG compliance environment variables should be set up to conform to the XDG Base Directory Specification. Additonally, manually set the locale environment variables for installing plugins with `pip` (These variables are handled in `zshenv` later on):
-```
+```bash
 [[ -n "$XDG_CONFIG_HOME" ]] || export XDG_CONFIG_HOME=$HOME/.config
 [[ -n "$XDG_CACHE_HOME"  ]] || export XDG_CACHE_HOME=$HOME/.cache
 [[ -n "$XDG_DATA_HOME"   ]] || export XDG_DATA_HOME=$HOME/.local/share
@@ -21,18 +21,22 @@ To ensure XDG compliance environment variables should be set up to conform to th
 ### Enabling multilib repositories
 Several applications require 32-bit libraries. These can be retrieved after enabling the `multilib` repository in `/etc/pacman.conf`. 
 
+```bash
+sed /etc/pacman.conf
+```
+
 ### Selecting the fastest mirror
 
-```
+```bash
 sudo pacman -S --noconfirm --needed reflector
 sudo reflector -l 100 -f 50 --sort rate --threads 5 --verbose --save /tmp/mirrorlist.new
 rankmirrors -n 0 /tmp/mirrorlist.new > /tmp/mirrorlistsudo 
 cp /tmp/mirrorlist /etc/pacman.d && sudo pacman -Syu
 ```
 
-### Install XOrg and video driver(s)
+### Install `X` and video driver(s)
 
-```
+```bash
 sudo pacman -S --noconfirm --needed \
    xorg-server xorg-apps xorg-xinit xorg-twm xterm xf86-video-intel
 ```
@@ -40,47 +44,60 @@ sudo pacman -S --noconfirm --needed \
 ### Install essential software
 The list below includes packages which are referenced or used in the various configuration files in this repository and create a working base install of the environment. All personal `$USER` applications have been omitted as they vary per system installation. Instead, these have been listed under the section 'Optional software packages' below. 
 
-```
+```bash
 sudo pacman -S --noconfirm --needed \   
-   acpi acpid alsa-firmware alsa-plugins alsa-utils android-tools ansible arandr baobab blueberry bluez-firmware bluez-utils bmon bridge-utils cheese cifs-utils cmake compton cups cups-pdf curl dhclient dialog dkms docker dunst etckeeper feh ffmpeg file-roller firefox flake8 flashplugin ghostscript gksu gnome-keyring gparted gsfonts gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer gvfs gvfs-mtp gvfs-nfs gvfs-smb hplip htop i3status imagemagick iperf iperf3 jre9-openjdk libcups libvirt linux-headers lm_sensors lsb-release lxappearance minicom mousetweaks mtr neovim net-tools networkmanager network-manager-applet nftables nmap numix-gtk-theme numlockx openconnect openssh openssl openvpn p7zip pavucontrol polkit powertop pulseaudio pulseaudio-alsa putty python python-pip python2 python2-pip ranger redshift remmina rofi ruby sane screen screenfetch scrot sshpass simple-scan sslscan xf86-input-libinput syncthing system-config-printer tcpdump thunar thunar-volman thunderbird tlp tlp-rdw tmux traceroute transmission-qt tree ttf-roboto udev udisks2 unrar unzip vagrant virt-manager virtualbox vlc wget whois wireshark-cli wireshark-common wireshark-qt x11-ssh-askpass xautolock xclip xdg-user-dirs xfce4-notes-plugin xss-lock zip zsh    
+   acpi acpid alsa-firmware alsa-plugins alsa-utils android-tools ansible arandr baobab blueberry bluez-firmware  \
+   bluez-utils bmon bridge-utils cheese cifs-utils cmake compton cups cups-pdf curl dhclient dialog dkms docker   \
+   dunst etckeeper feh ffmpeg file-roller firefox flake8 flashplugin ghostscript git gksu gnome-keyring gparted   \
+   gsfonts gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer gvfs gvfs-mtp gvfs-nfs    \
+   gvfs-smb hplip htop i3status imagemagick iperf iperf3 jre9-openjdk libcups libvirt linux-headers lm_sensors    \
+   lsb-release lxappearance minicom mousetweaks mtr neovim net-tools networkmanager network-manager-applet        \
+   nftables nmap numix-gtk-theme numlockx openconnect openssh openssl openvpn p7zip pavucontrol polkit powertop   \
+   pulseaudio pulseaudio-alsa putty python python-pip python2 python2-pip ranger redshift remmina rofi ruby sane  \
+   screen screenfetch scrot sshpass simple-scan sslscan xf86-input-libinput syncthing system-config-printer       \
+   tcpdump thunar thunar-volman thunderbird tlp tlp-rdw tmux traceroute transmission-qt tree ttf-roboto udev      \
+   udisks2 unrar unzip vagrant virt-manager virtualbox vlc wget whois wireshark-cli wireshark-common wireshark-qt \
+   x11-ssh-askpass xautolock xclip xdg-user-dirs xfce4-notes-plugin xss-lock zip zsh    
 
 ```
-In order to trigger `.zlogin` (and thus the following `.xinitrc`), `zsh` should be made the default login shell for the current user:
-```
+If `zsh` wasn't chosen to be the default shell at the time of creating the user we should set it now. This is needed in order to trigger `.zlogin` (and thus the following `.xinitrc`).
+```bash
 sudo chsh $USER -s /bin/zsh
 ```
+
 Additionally, `zsh` can be made XDG compliant by including the default XDG directories in `/etc/zsh/zshrc`. This way, `zsh` looks for its configuration files in `$XDG_CONFIG_HOME`: 
-```
+```bash
 echo -e "\nif [[ -z "$XDG_CONFIG_HOME" ]]; then\n  export XDG_CONFIG_HOME="$HOME/.config/"\nfi\n\nif [[ -d "$XDG_CONFIG_HOME/zsh" ]]; then\n  export ZDOTDIR="$XDG_CONFIG_HOME/zsh/"\nfi" | sudo tee -a /etc/zsh/zshenv
 ```
-### Install AUR helper `pacaur` 
+
+### Install AUR helper **`trizen`** 
+```bash
+mkdir `$XDG_CONFIG_HOME/git/`
+git clone https://aur.archlinux.org/trizen.git $!
+cd `$XDG_CONFIG_HOME/git/` && makepkg -si --noconfirm
 ```
-curl -Ls https://goo.gl/cF2iJy | bash
-```
+
 ### Installing additional software
-```
-pacaur -S --noconfirm --noedit universal-ctags-git rxvt-unicode-patched arping-th ostinato solaar gnome-ssh-askpass2 rar font-manager hardcode-fixer-git dropbox foxitreader numix-icon-theme-git numix-circle-icon-theme-git neofetch pkgcacheclean slack-desktop spotify keepassxc-git davmail ttf-fantasque-sans-mono powerline-fonts-git ttf-font-awesome-4 gtk-theme-arc-git icaclient eve-ng-integration i3lock-color-git j4-dmenu-desktop i3blocks i3-gaps-next-git teamviewer remmina-plugin-teamviewer displaylink
+```bash
+trizen -S --noconfirm --noedit \
+   universal-ctags-git rxvt-unicode-patched arping-th ostinato solaar gnome-ssh-askpass2 rar font-manager \
+   hardcode-fixer-git dropbox foxitreader numix-icon-theme-git numix-circle-icon-theme-git neofetch       \
+   pkgcacheclean slack-desktop spotify keepassxc-git davmail ttf-fantasque-sans-mono powerline-fonts-git  \
+   ttf-font-awesome-4 gtk-theme-arc-git icaclient eve-ng-integration i3lock-color-git j4-dmenu-desktop    \
+   i3blocks i3-gaps-next-git teamviewer remmina-plugin-teamviewer displaylink
 ```
 
 ### Setting up plugin manager(s)
 `vim-plug` allows for leveraging `nvim`'s asynchronous behavior. `zsh` plugins are handled by `zplug` which is self-contained within `$XDG_CONFIG_HOME/zsh/.zshrc`.
-```
+```bash
 # vim-plug
 curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
-### Enable services
-```
-sudo systemctl enable NetworkManager.service
-sudo systemctl enable org.cups.cupsd.service
-sudo systemctl enable bluetooth.service
-sudo systemctl enable sshd.service
-```
-
 ### Clone dotfiles into correct directories
 This method is courtesy of `/u/StreakyCobra` and is explained in more detail in https://goo.gl/hToRQZ. 
-```
+```bash
 # Set up cfg alias and clone the repo
 alias cfg='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
 git clone --bare https://github.com/siemhermans/cfg $HOME/.cfg
@@ -99,7 +116,7 @@ Future configuration files can be added or removed by leveraging the `cfg` alias
 ### Install plugins
 `nvim` plugins can be installed directly from the command line with the command below. The `zsh` plugins should be automatically installed by `zplug` the first time `zshrc` is read. `urxvt` plugins are handled directly in `$XDG_CONFIG_HOME/X11/Xresources` and are included in the repository. 
 
-```
+```bash
 # Install Python related dependencies for Neovim:
 pip3 install neovim flake8 pylint
 
@@ -111,41 +128,46 @@ mkdir $XDG_CONFIG_HOME/zsh/plugins/    # Create local plugin repository
 zsh && zplug install
 ```
 
+### Starting default services
+```bash
+sudo systemctl enable NetworkManager.service
+sudo systemctl enable org.cups.cupsd.service
+sudo systemctl enable bluetooth.service
+sudo systemctl enable sshd.service
+
+# Reboot the system
+sudo reboot
+```
+
 ### Miscellaneous configuration
 
 #### Power button behavior
 By modifying the Power Button behavior in `logind`, i3 can handle poweroff behavior. In this instance, the power button is handled in `$mode_system` in i3. Note that this modification can only be performed as a privileged user.
-```
+```bash
 sudo sed -i '/HandlePowerKey/{s/poweroff/ignore/g;s/#//g}' /etc/systemd/logind.conf
-```
-
-#### Disabling Optimus
-Given a notebook with an Optimus configuration on which the official NVIDIA drivers have been installed, including the following command in `/etc/rc.local` allows for automatically switching to the Intel GPU when booting (thus prolonging battery life).
-```
-sudo sed -i '$i prime-switch' /etc/rc.local
 ```
 
 #### Modifying banner files
 Edit the default message when logging in from the console (`ttyX`). 
-```
+```bash
 echo -e "Use of this system constitutes consent to monitoring. Monitoring may be\nconducted for the protection against improper or unauthorized use or access.\n\n" | sudo tee /etc/issue
 ```
 
 #### Fixing audio popping on the Dell E7470
 The Dell E7470 suffers from occasional audio popping when running the 4.X kernel branch. As a workaround the loopback device can be disabled by running the command below and navigating to the specific device. 
-```
+```bash
 alsamixer -c0
 ```
 
 #### Reverting to normal interface names
-By default Ubuntu performs dynamic naming of network interfaces. To revert to a more human-readable scheme of `'ethX'` and `'wlanX'` the following line in `/etc/default/grub` can be changed:
+By default `systemd-networkd` performs dynamic naming of network interfaces. To revert to a more human-readable scheme of `'ethX'` and `'wlanX'` the following line in `/etc/default/grub` can be changed:
 
-```
+```bash
 sed -i '/GRUB_CMDLINE_LINUX/{s/\"\"/\"net\.ifnames\=0\"/g;s/#//g}' /etc/default/grub
 ```
 ### Correcting permissions
 In order to run `minicom`, `pcap` without root permissions and allow device mounting in `virtualbox` the following groups should be added to the current user:
 
-```
-sudo usermod -aG dialout,wireshark,virtualbox $USER
+```bash
+sudo usermod -aG wireshark,vboxusers,libvirtd,docker $USER
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In /etc/lvm/lvm.conf, enable issue_discards=1 option.
 
 sudo systemctl enable fstrim.timer
 
-
+Check whether swap works with `swapon --output-all` and `ls -l /dev/mapper/`
 
 Lastly, add rd.luks.options=discard in your kernel boot options
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # :wrench: .cfg
-This repo contains a snapshot of my ([**@siemhermans**](https://twitter.com/siemhermans)) configuration files. This README provides sources for installing a base Arch Linux system and a step by step build instruction for converting the system into my preferred working environment.
+This repo contains a snapshot of my ([**@siemhermans**](https://twitter.com/siemhermans)) configuration files and a guide for setting up a minimal Arch Linux system based around the `i3` window manager. This **README** provides sources for installing a base system and a step by step build instruction for converting that system into my personally preferred working environment.
 
-# System installation
-[@HardenedArray](https://github.com/HardenedArray) has provided an excellent `gist` on installing an Arch Linux system with encrypted root and swap filesystems and UEFI-booting compatibility. I highly suggest following the steps outlined in this [**guide**](https://gist.github.com/HardenedArray/31915e3d73a4ae45adc0efa9ba458b07).
+## Base system installation
+[@HardenedArray](https://github.com/HardenedArray) has provided an excellent `gist` on installing an Arch Linux system with UEFI-booting compatibility and encrypted root and swap filesystems. I highly suggest following the steps outlined in this [**guide**](https://gist.github.com/HardenedArray/31915e3d73a4ae45adc0efa9ba458b07) as the following sections pick up where the user is left off after installing.
 
+## Building a working environment
+The following steps set up the correct `env` variables, install essential software packages, plugin managers and fonts, install plugins for `zsh` and `nvim` and clone the dotfiles provided in this repository into the correct directories. Where possible, all configuration files follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html). Parts of the software selection for setting up `i3` and `xorg` build on [@erikdubois](https://github.com/erikdubois/Archi3)' installation scripts.
 
-# Environment setup
-The following steps set up the correct `env` variables, install essential software packages, plugin managers and fonts, install plugins for `zsh` and `nvim` and clone the dotfiles provided in this repository into the correct directories. Where possible, all configuration files follow the XDG Base Directory Specification. Parts of the software selection for setting up `i3` and `xorg` build on [@erikdubois](https://github.com/erikdubois/Archi3)' installation scripts.
+#### Defining `env` variables
+To ensure XDG compliance during the installation process, environment variables should temporarily be set up to conform to the XDG specification. These variables will be handled in `/etc/zsh/zshenv` in the final setup, causing them to be loaded when `zsh` starts. As `zsh` will be set as the default shell for the main user, this in turn happens when `$USER` logs in. Additonally, to be able to install Python packages with `pip`, the locale environment variables should be set: 
 
-### Defining `env` variables
-To ensure XDG compliance environment variables should be set up to conform to the XDG Base Directory Specification. Additonally, manually set the locale environment variables for installing plugins with `pip` (These variables are handled in `zshenv` later on):
 ```bash
 [[ -n "$XDG_CONFIG_HOME" ]] || export XDG_CONFIG_HOME=$HOME/.config
 [[ -n "$XDG_CACHE_HOME"  ]] || export XDG_CACHE_HOME=$HOME/.cache
@@ -18,73 +18,97 @@ To ensure XDG compliance environment variables should be set up to conform to th
 [[ -n "$LC_CTYPE" ]] || export LC_CTYPE="en_US.UTF-8"
 ```
 
-### Enabling multilib repositories
-Several applications require 32-bit libraries. These can be retrieved after enabling the `multilib` repository in `/etc/pacman.conf`. 
-
-```bash
-sed /etc/pacman.conf
-```
-
-### Selecting the fastest mirror
+#### Selecting the fastest mirror *(Optional)*
+Prior to installing any software it may be beneficial to select the fastest available mirror(s) for `pacman`. This can be done by manually selecting regional mirrors in `/etc/pacman.d/mirrors` to be preferred. Alternatively `reflector` can be used to actively test the available mirrors and select the best ones based on bandwidth and response times.  
 
 ```bash
 sudo pacman -S --noconfirm --needed reflector
 sudo reflector -l 100 -f 50 --sort rate --threads 5 --verbose --save /tmp/mirrorlist.new
-rankmirrors -n 0 /tmp/mirrorlist.new > /tmp/mirrorlistsudo 
-cp /tmp/mirrorlist /etc/pacman.d && sudo pacman -Syu
+
+# Populate the new mirrorlist
+rankmirrors -n 0 /tmp/mirrorlist.new > /tmp/mirrorlistsudo
+sudo cp /tmp/mirrorlist /etc/pacman.d
 ```
 
-### Install `X` and video driver(s)
+#### Enabling multilib repositories
+Several of the applications to be installed require additional 32-bit libraries. These can be retrieved after enabling the `multilib` repository in `/etc/pacman.conf`: 
 
 ```bash
-sudo pacman -S --noconfirm --needed \
-   xorg-server xorg-apps xorg-xinit xorg-twm xterm xf86-video-intel
+sudo sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+
+# Update packages and package lists 
+sudo pacman -Syu
 ```
 
-### Install essential software
-The list below includes packages which are referenced or used in the various configuration files in this repository and create a working base install of the environment. All personal `$USER` applications have been omitted as they vary per system installation. Instead, these have been listed under the section 'Optional software packages' below. 
+#### Installing an AUR helper
+Some of the packages related to `i3` are only available in the Arch User Repository (AUR). In order to take the strain out of manually keeping these packages up to date we will be installing an AUR helper. Although these helpers come in many shapes and forms I've settled on `trizen` which effectively functions as a drop-in replacement for the now deprecated `pacaur`.
 
-```bash
-sudo pacman -S --noconfirm --needed \   
-   acpi acpid alsa-firmware alsa-plugins alsa-utils android-tools ansible arandr baobab blueberry bluez-firmware  \
-   bluez-utils bmon bridge-utils cheese cifs-utils cmake compton cups cups-pdf curl dhclient dialog dkms docker   \
-   dunst etckeeper feh ffmpeg file-roller firefox flake8 flashplugin ghostscript git gksu gnome-keyring gparted   \
-   gsfonts gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer gvfs gvfs-mtp gvfs-nfs    \
-   gvfs-smb hplip htop i3status imagemagick iperf iperf3 jre9-openjdk libcups libvirt linux-headers lm_sensors    \
-   lsb-release lxappearance minicom mousetweaks mtr neovim net-tools networkmanager network-manager-applet        \
-   nftables nmap numix-gtk-theme numlockx openconnect openssh openssl openvpn p7zip pavucontrol polkit powertop   \
-   pulseaudio pulseaudio-alsa putty python python-pip python2 python2-pip ranger redshift remmina rofi ruby sane  \
-   screen screenfetch scrot sshpass simple-scan sslscan xf86-input-libinput syncthing system-config-printer       \
-   tcpdump thunar thunar-volman thunderbird tlp tlp-rdw tmux traceroute transmission-qt tree ttf-roboto udev      \
-   udisks2 unrar unzip vagrant virt-manager virtualbox vlc wget whois wireshark-cli wireshark-common wireshark-qt \
-   x11-ssh-askpass xautolock xclip xdg-user-dirs xfce4-notes-plugin xss-lock zip zsh    
-
-```
-If `zsh` wasn't chosen to be the default shell at the time of creating the user we should set it now. This is needed in order to trigger `.zlogin` (and thus the following `.xinitrc`).
-```bash
-sudo chsh $USER -s /bin/zsh
-```
-
-Additionally, `zsh` can be made XDG compliant by including the default XDG directories in `/etc/zsh/zshrc`. This way, `zsh` looks for its configuration files in `$XDG_CONFIG_HOME`: 
-```bash
-echo -e "\nif [[ -z "$XDG_CONFIG_HOME" ]]; then\n  export XDG_CONFIG_HOME="$HOME/.config/"\nfi\n\nif [[ -d "$XDG_CONFIG_HOME/zsh" ]]; then\n  export ZDOTDIR="$XDG_CONFIG_HOME/zsh/"\nfi" | sudo tee -a /etc/zsh/zshenv
-```
-
-### Install AUR helper **`trizen`** 
 ```bash
 mkdir `$XDG_CONFIG_HOME/git/`
 git clone https://aur.archlinux.org/trizen.git $!
 cd `$XDG_CONFIG_HOME/git/` && makepkg -si --noconfirm
 ```
 
-### Installing additional software
+#### Installing essential utilities
+At this point we are ready to install core utilities such as the X Window System, the Window Manager, audio and video drivers, storage drivers and networking tools. The list below includes packages which are referenced or used in the various configuration files in this repository and create a working base install of the environment. All personal `$USER` applications have been omitted as they vary per system installation. Instead, these have been listed under the following 'Additional software packages' section below.
+
 ```bash
-trizen -S --noconfirm --noedit \
-   universal-ctags-git rxvt-unicode-patched arping-th ostinato solaar gnome-ssh-askpass2 rar font-manager \
-   hardcode-fixer-git dropbox foxitreader numix-icon-theme-git numix-circle-icon-theme-git neofetch       \
-   pkgcacheclean slack-desktop spotify keepassxc-git davmail ttf-fantasque-sans-mono powerline-fonts-git  \
-   ttf-font-awesome-4 gtk-theme-arc-git icaclient eve-ng-integration i3lock-color-git j4-dmenu-desktop    \
-   i3blocks i3-gaps-next-git teamviewer remmina-plugin-teamviewer displaylink
+# Official repositories
+sudo pacman -S --noconfirm --needed \  
+   acpi acpid alsa-firmware alsa-plugins alsa-utils blueberry bluez-firmware bluez-utils    \
+   bridge-utils cifs-utils cmake cups cups-pdf curl dhclient dialog dkms dunst etckeeper    \
+   feh ffmpeg ghostscript git gksu gnome-keyring gsfonts gst-plugins-bad gst-plugins-base   \
+   gst-plugins-good gst-plugins-ugly gstreamer gvfs gvfs-mtp gvfs-nfs gvfs-smb i3status     \
+   imagemagick iperf iperf3 libcups linux-headers lsb-release mousetweaks neovim net-tools  \
+   network-manager-applet networkmanager numlockx openssh openssl p7zip pavucontrol polkit  \
+   pulseaudio pulseaudio-alsa python python2 python2-pip python-pip rofi ruby sane scrot    \
+   simple-scan sshpass system-config-printer tlp tlp-rdw tree udev udisks2 unrar unzip wget \
+   x11-ssh-askpass xautolock xclip xdg-user-dirs xf86-input-libinput xf86-video-intel       \
+   xorg-apps xorg-server xorg-twm xorg-xinit xss-lock xterm zip zsh 
+
+# AUR
+sudo trizen -S --noconfirm --noedit \
+   i3blocks i3-gaps-next-git i3lock-color-git j4-dmenu-desktop rxvt-unicode-patched
+```
+
+If `zsh` wasn't chosen to be the default shell at the time of creating the user we should set it now. This is needed in order to trigger `.zlogin` and thus the following `.xinitrc` which in turn starts the `X` server.
+
+```bash
+sudo chsh $USER -s /bin/zsh
+```
+
+Additionally, `zsh` can be made XDG compliant by including the default XDG directories in `/etc/zsh/zshrc`. This way, `zsh` looks for its configuration files in `$XDG_CONFIG_HOME`:
+
+```bash
+echo -e "\nif [[ -z "$XDG_CONFIG_HOME" ]]; then\n  export XDG_CONFIG_HOME="$HOME/.config/"\nfi\n\nif [[ -d "$XDG_CONFIG_HOME/zsh" ]]; then\n  export ZDOTDIR="$XDG_CONFIG_HOME/zsh/"\nfi" | sudo tee -a /etc/zsh/zshenv
+```
+
+### Installing additional software *(Optional)*
+
+```
+# Official repositories
+sudo pacman -S --noconfirm --needed \ 
+	android-tools ansible arandr baobab bmon cheese compton docker file-roller firefox      \
+   flake8 flashplugin gparted hplip htop jre9-openjdk libvirt lm_sensors lxappearance      \
+   mtr nftables nmap numix-gtk-theme openconnect openvpn powertop putty ranger redshift    \
+   remmina screen screenfetch sslscan syncthing tcpdump thunar thunar-volman thunderbird   \
+   tmux traceroute transmission-qt ttf-roboto vagrant virt-manager virtualbox vlc whois    \
+   wireshark-cli wireshark-common wireshark-qt xfce4-notes-plugin
+
+# AUR
+sudo trizen -S --noconfirm --noedit \
+  	arping-th davmail displaylink dropbox eve-ng-integration font-manager foxitreader       \
+   gnome-ssh-askpass2 gtk-theme-arc-git hardcode-fixer-git icaclient keepassxc-git         \
+   neofetch numix-circle-icon-theme-git numix-icon-theme-git ostinato pkgcacheclean        \
+   powerline-fonts-git rar remmina-plugin-teamviewer rxvt-unicode-patched slack-desktop    \
+   solaar spotify teamviewer ttf-fantasque-sans-mono ttf-font-awesome-4 universal-ctags-git
+```
+
+### Correcting permissions
+In order to run `pcap` without root permissions and allow device mounting in `virtualbox` the following groups should be added to the current user:
+
+```bash
+sudo usermod -aG wireshark,vboxusers,libvirtd,docker $USER
 ```
 
 ### Setting up plugin manager(s)
@@ -96,7 +120,8 @@ curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
 ```
 
 ### Clone dotfiles into correct directories
-This method is courtesy of `/u/StreakyCobra` and is explained in more detail in https://goo.gl/hToRQZ. 
+This method is courtesy of `/u/StreakyCobra` and is explained in more detail in the [Atlassian Developer blog]( https://developer.atlassian.com/blog/2016/02/best-way-to-store-dotfiles-git-bare-repo/).
+
 ```bash
 # Set up cfg alias and clone the repo
 alias cfg='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
@@ -118,7 +143,7 @@ Future configuration files can be added or removed by leveraging the `cfg` alias
 
 ```bash
 # Install Python related dependencies for Neovim:
-pip3 install neovim flake8 pylint
+pip install neovim flake8 pylint
 
 # Pull down all plugins for Neovim
 nvim +PlugInstall +UpdateRemotePlugins
@@ -134,9 +159,6 @@ sudo systemctl enable NetworkManager.service
 sudo systemctl enable org.cups.cupsd.service
 sudo systemctl enable bluetooth.service
 sudo systemctl enable sshd.service
-
-# Reboot the system
-sudo reboot
 ```
 
 ### Miscellaneous configuration
@@ -164,10 +186,4 @@ By default `systemd-networkd` performs dynamic naming of network interfaces. To 
 
 ```bash
 sed -i '/GRUB_CMDLINE_LINUX/{s/\"\"/\"net\.ifnames\=0\"/g;s/#//g}' /etc/default/grub
-```
-### Correcting permissions
-In order to run `minicom`, `pcap` without root permissions and allow device mounting in `virtualbox` the following groups should be added to the current user:
-
-```bash
-sudo usermod -aG wireshark,vboxusers,libvirtd,docker $USER
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # :wrench: .cfg
+This repo contains a snapshot of my ([**@siemhermans**](https://twitter.com/siemhermans)) configuration files. This README provides sources for installing a base Arch Linux system and a step by step build instruction for converting the system into my preferred working environment.
 
-This is a **snapshot** of my ([**@siemhermans**](https://twitter.com/siemhermans)) configuration files. The description below provides a step by step manual for installing a working environment assuming a Ubuntu Server image is used. 
+# System installation
+[@HardenedArray](https://github.com/HardenedArray) has provided an excellent `gist` on installing an Arch Linux system with encrypted root and swap filesystems and UEFI-booting compatibility. I highly suggest following the steps outlined in this [**guide**](https://gist.github.com/HardenedArray/31915e3d73a4ae45adc0efa9ba458b07).
 
-# Installation steps
-The following steps set up the correct `env` variables, install essential software packages, plugin managers and fonts, install plugins for `zsh` and `nvim` and clone the dotfiles in this repository into the correct directories. Where possible, all configuration files follow the XDG Base Directory Specification. 
+
+# Environment setup
+The following steps set up the correct `env` variables, install essential software packages, plugin managers and fonts, install plugins for `zsh` and `nvim` and clone the dotfiles provided in this repository into the correct directories. Where possible, all configuration files follow the XDG Base Directory Specification. Parts of the software selection for setting up `i3` and `xorg` build on [@erikdubois](https://github.com/erikdubois/Archi3)' installation scripts.
 
 ### Defining `env` variables
-Define environment variables conforming to the XDG Base Directory Specification. Additonally, manually set the locale environment variables for installing plugins with `pip` (These variables are handled in `zshenv` later on):
+To ensure XDG compliance environment variables should be set up to conform to the XDG Base Directory Specification. Additonally, manually set the locale environment variables for installing plugins with `pip` (These variables are handled in `zshenv` later on):
 ```
 [[ -n "$XDG_CONFIG_HOME" ]] || export XDG_CONFIG_HOME=$HOME/.config
 [[ -n "$XDG_CACHE_HOME"  ]] || export XDG_CACHE_HOME=$HOME/.cache


### PR DESCRIPTION
### HDMI Auto connect Audio and Screen duplication:

On connecting an HDMI cable the below code will execute which attaches the `PulseAudio` feed to the HDMI cable and starts `Arandr` with screen_layout_x.

Original documentation:
[https://wiki.archlinux.org/index.php/PulseAudio/Examples#Simultaneous_HDMI_and_analog_output](url)

Create a file `$XDG_CONFIG_HOME/scripts/hdmi_toggle.sh` this will allows automatically attachment of your audio feed to the HDMI channel.

```

#!/bin/bash

export PATH=/usr/bin

USER_NAME=$(who | awk -v vt=tty$(fgconsole) '$0 ~ vt {print $1}')
USER_ID=$(id -u "$USER_NAME")
CARD_PATH="/sys/class/drm/card0/"
AUDIO_OUTPUT="analog-surround-40"
PULSE_SERVER="unix:/run/user/"$USER_ID"/pulse/native"

for OUTPUT in $(cd "$CARD_PATH" && echo card*); do
  OUT_STATUS=$(<"$CARD_PATH"/"$OUTPUT"/status)
  if [[ $OUT_STATUS == connected ]]
  then
    echo $OUTPUT connected
    case "$OUTPUT" in
      "card0-HDMI-A-1")
        AUDIO_OUTPUT="hdmi-stereo" # Digital Stereo (HDMI 1)
     ;;
      "card0-HDMI-A-2")
        AUDIO_OUTPUT="hdmi-stereo-extra1" # Digital Stereo (HDMI 2)
     ;;
    esac
  fi
done
echo selecting output $AUDIO_OUTPUT
sudo -u "$USER_NAME" pactl --server "$PULSE_SERVER" set-card-profile 0 output:$AUDIO_OUTPUT+input:analog-stereo

#Video output selection:
i3 ............

```

Make the script executable: 
`chmod +x $XDG_CONFIG_HOME/scripts/hdmi_sound_toggle.sh`

Create a udev rule to run this script when the status of the HDMI change:
 `sudo vim /etc/udev/rules.d/99-hdmi_sound_video.rules`

```
KERNEL=="card0", SUBSYSTEM=="drm", ACTION=="change", RUN+="$XDG_CONFIG_HOME/scripts/hdmi_toggle.sh"
```

After you can try the following command which activates the configuration or tells that you need to reboot before activation: 
`udevadm control --reload-rules`
